### PR TITLE
Add support for binding time.Time values in SQL queries

### DIFF
--- a/libsql.go
+++ b/libsql.go
@@ -526,6 +526,10 @@ func (c *conn) execute(query string, args []sqldriver.NamedValue, exec bool) (C.
 				valueInt = 0
 			}
 			statusCode = C.libsql_bind_int(stmt, C.int(idx), C.longlong(valueInt), &errMsg)
+		case time.Time:
+			valueStr := C.CString(arg.Value.(time.Time).Format(time.RFC3339Nano))
+			statusCode = C.libsql_bind_string(stmt, C.int(idx), valueStr, &errMsg)
+			C.free(unsafe.Pointer(valueStr))
 		default:
 			return nil, fmt.Errorf("unsupported type %T", arg.Value)
 		}


### PR DESCRIPTION
SQLite does not have a storage class set aside for storing dates and/or times. Instead, the built-in Date And Time Functions of SQLite are capable of storing dates and times as TEXT, REAL, or INTEGER values[^1]

I have added functionality to bind time.Time values as strings.

[^1]: https://www.sqlite.org/datatype3.html#date_and_time_datatype