### PR TITLE
Fix support for `Scan`s of `time.Time` in `time.RFC3339Nano` format

### DIFF
--- a/libsql.go
+++ b/libsql.go
@@ -749,6 +749,7 @@ Outerloop:
 			str := C.GoString(ptr)
 			C.libsql_free_string(ptr)
 			for _, format := range []string{
+				time.RFC3339Nano,
 				"2006-01-02 15:04:05.999999999-07:00",
 				"2006-01-02T15:04:05.999999999-07:00",
 				"2006-01-02 15:04:05.999999999",


### PR DESCRIPTION
This commit introduces support for parsing `time.RFC3339Nano` which is commonly used in Go-based projects for fine-grain time representation.  The introduction of this format therefor allows for better compatibility when switching between other Go-based SQLite libraries.

Without this change, it is possible to receive the following error:

```
unsupported Scan, storing driver.Value type string into type *time.Time
```