### PR TITLE
Fix support for Scans of time.Time in time.RFC3339Nano format

### DIFF
--- a/libsql.go
+++ b/libsql.go
@@ -747,6 +747,7 @@ Outerloop:
 				return libsqlError(fmt.Sprint("failed to get string for column ", i), statusCode, errMsg)
 			}
 			str := C.GoString(ptr)
+			str = strings.TrimSuffix(str, "Z")
 			C.libsql_free_string(ptr)
 			for _, format := range []string{
 				"2006-01-02 15:04:05.999999999-07:00",


### PR DESCRIPTION
Fixes: #tursodatabase/go-libsql/issues/43

The mattn/go-sqlite3 library removes the "Z" suffix from timestamps 
```
str = strings.TrimSuffix(str, "Z")
```
 in [mattn/go-sqlite3/sqlite3.go](https://github.com/mattn/go-sqlite3/blob/master/sqlite3.go#L2260).
