### PR TITLE
Set deployment target for macOS binaries

### DIFF
--- a/.github/workflows/update-libsql.yml
+++ b/.github/workflows/update-libsql.yml
@@ -123,6 +123,8 @@ jobs:
 
       - name: Build libsql for macOS
         working-directory: libsql/bindings/c
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "13.0"
         run: |
           cargo build --release
 


### PR DESCRIPTION
fixes #85 

Without this patch, we will keep seeing warnings when go-libsql is run on a latest macOS machine than the libs were compiled on. 

I tested this patch on my repo: 

1. Before: https://github.com/avinassh/go-libsql/actions/runs/20717982667/job/59474230910 you can see the warnings in "Verify Darwin ARM64 build" step:

```
ld: warning: object file (/Users/runner/work/go-libsql/go-libsql/lib/darwin_arm64/libsql_experimental.a(fad98b632b8ce3cc-curve25519.o)) was built for newer macOS version (15.5) than being linked (15.0)
ld: warning: object file (/Users/runner/work/go-libsql/go-libsql/lib/darwin_arm64/libsql_experimental.a(ca4b6ef5433f5aeb-aes_nohw.o)) was built for newer macOS version (15.5) than being linked (15.0)
ld: warning: object file (/Users/runner/work/go-libsql/go-libsql/lib/darwin_arm64/libsql_experimental.a(ca8bd8684bb569fa-montgomery.o)) was built for newer macOS version (15.5) than being linked (15.0)
```

2. After: https://github.com/avinassh/go-libsql/actions/runs/20717997011/job/59474229277

---

Thank you @ThomasGormley for the quick solution as well