### PR TITLE
Deprecate Connector.Sync() with godoc annotation

### DIFF
--- a/libsql.go
+++ b/libsql.go
@@ -293,6 +293,7 @@ type Connector struct {
 	closeAckCh  <-chan struct{}
 }
 
+// Deprecated: Sync is deprecated and will be removed in a future release. Use the `tursogo` package instead. Learn more: https://tur.so/newsync
 func (c *Connector) Sync() (Replicated, error) {
 	return libsqlSync(c.nativeDbPtr)
 }


### PR DESCRIPTION
Add the // Deprecated: godoc comment so linters and IDEs flag usage. Users are directed to the `tursogo` package as a replacement. Learn more: https://tur.so/newsync